### PR TITLE
Fix render_view() for use CI Output Class

### DIFF
--- a/application/libraries/Layout.php
+++ b/application/libraries/Layout.php
@@ -1424,7 +1424,7 @@ class Layout
 
         $output = $this->CI->load->view('../templates/' . $current_root_template . '/' . $current_root_template, array('CI' => $this->CI), true);
 
-        echo $output;
+        $this->CI->output->set_output($output);
     }
 
     /**


### PR DESCRIPTION
Change render_view() for use CI Output Class instead echo.
This change allow use pseudo variables by default such as {elapsed_time}.
It's related to #3 